### PR TITLE
Make process of adding new things more reliable.

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -14,6 +14,8 @@ from requests_futures.sessions import FuturesSession
 
 from tornado.websocket import websocket_connect
 
+from webthing.utils import get_ip
+
 class GatewayConfig:
 
     def __init__(self):
@@ -310,5 +312,24 @@ class Gateway:
 
     def url(self, path=''):
         return self.gateway_url + path
+
+    def setAdapterConfig(self, port_start, num_things):
+        ip = get_ip()
+        data = {
+            'config': {
+                'pollInterval': 30,
+                'urls': ['http://{}:{}/'.format(ip, port) for port in range(port_start, port_start + num_things)],
+            },
+        }
+        self.put('/addons/thing-url-adapter/config', data=data)
+
+    def clearAdapterConfig(self):
+        data = {
+            'config': {
+                'pollInterval': 30,
+                'urls': [],
+            },
+        }
+        self.put('/addons/thing-url-adapter/config', data=data)
 
 requests.packages.urllib3.disable_warnings()

--- a/test.py
+++ b/test.py
@@ -72,6 +72,9 @@ class GatewayTest(unittest.TestCase):
             self.tws[port] = (tt, tws)
             self.new[port] = False
 
+        # Update the config for thing-url-adapter to speed up discovery
+        self.gw.setAdapterConfig(CONFIG['things']['port_start'], num_things)
+
         # Wait for gateway websocket to indicate that all things are ready
         print('{} Waiting for {} webthings'.format(datetime.now(), len(list(self.tws.keys()))))
         skt = loop.run_until_complete(self.gw.newThingsWebsocket())
@@ -475,6 +478,8 @@ def cleanup_all_webthings():
     things = gw.things()
     for thing in things:
         gw.deleteThing(thing)
+
+    gw.clearAdapterConfig()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows the Web Thing adapter to probe URLs directly, rather
than relying on mDNS.